### PR TITLE
feature: Suggest using `date +%s` command to obtain Unix epoch timestamps

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,7 @@ Run the following command to report each deployment:
 
 ### Incidents
 
-Report an event to Pulse whenever there is a software release or infrastructure configuration change to production that results in degraded service and subsequently required remediation:
+Report an event to Pulse whenever an incident resulting from a release or infrastructure configuration change to production is solved. Incidents are any form of degraded service that require remediation:
 
 -   The incident is **created** when you detect a service impairment or service outage in production.
 -   The incident is **resolved** when you apply a hotfix or patch, or when you rollback the changes to restore the service in production.

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ Run the following command to report each change:
 ./event-cli push change \
     --api-key "<API KEY>" \
     --identifier "<change identifier>" \
-    --timestamp "<timestamp>"
+    --timestamp "$(date +%s)"
 ```
 
 ### Deployments
@@ -99,7 +99,7 @@ Run the following command to report each deployment:
 ./event-cli push deployment \
     --api-key "<API KEY>" \
     --identifier "<deployment identifier>" \
-    --timestamp "<timestamp>" \
+    --timestamp "$(date +%s)" \
     <space-separated list of commit identifiers>
 ```
 
@@ -129,7 +129,7 @@ Run the following command to report each incident:
     --api-key "<API KEY>" \
     --identifier "<incident identifier>" \
     --timestampCreated "<timestampCreated>" \
-    --timestampResolved "<timestampResolved>"
+    --timestampResolved "$(date +%s)"
 ```
 
 ## Examples


### PR DESCRIPTION
I inadvertently removed this extra guidance on a previous pull request.

Although this simple solution does not work on Windows, to be fair, neither does running the CLI with the syntax `./event-cli`. We'll figure out a solution to provide guidance for Windows systems on a different iteration.