### PR TITLE
feature: Add minimal contributing instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# pulse-user-docs
+# Pulse documentation
+
+<https://docs.acceleratedevops.net/>
+
+## Contributing to the documentation
+
+Contributions to the documentation are very welcome!
+
+See the following sections (from the CONTRIBUTING.md of codacy/docs) to:
+
+-   [Set up your environment to preview your changes locally](https://github.com/codacy/docs/blob/master/CONTRIBUTING.md#previewing-docs-locally)
+-   [Follow the Markdown conventions used in this repository](https://github.com/codacy/docs/blob/master/CONTRIBUTING.md#markdown-conventions)
+
+## What is Pulse
+
+See [accelerateddevops.net](http://acceleratedevops.net/) for information on:
+
+-   Getting visibility on your organization's performance
+-   Identify areas to improve
+-   Making progress toward becoming an elite performer.


### PR DESCRIPTION
To simplify, for now I'm linking to already existing content on the [codacy/docs](https://github.com/codacy/docs) repository.