### PR TITLE
feature: Update documentation domain

### DIFF
--- a/.github/workflows/mkdocs-deploy-gh-pages.yml
+++ b/.github/workflows/mkdocs-deploy-gh-pages.yml
@@ -16,4 +16,4 @@ jobs:
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CUSTOM_DOMAIN: docs.acceleratedevops.net
+          CUSTOM_DOMAIN: docs.pulse.codacy.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pulse documentation
 
-<https://docs.acceleratedevops.net/>
+<https://docs.pulse.codacy.com/>
 
 ## Contributing to the documentation
 


### PR DESCRIPTION
On the docs repository side, this is the change necessary to update the domain to `docs.pulse.codacy.com`.

**Note:** We must ensure that the old URL (https://docs.acceleratedevops.net/) redirects to the new one, so links to the documentation sent in emails to customers keep working.