### PR TITLE
clean: Prevent remark-stringify from incrementing list markers

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,4 +1,7 @@
 {
+  "settings": {
+    "incrementListMarker": false
+  },
   "plugins": [
     "preset-lint-consistent",
     "preset-lint-recommended",
@@ -11,3 +14,4 @@
     ]
   ]
 }
+


### PR DESCRIPTION
I was finally able to configure the `.remarkrc` file so that the Visual Studio Code extension [Remark](https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-remark) no longer increments the ordered list item markers.

(This pull request syncs the configuration with the one on the codacy/docs repository, see https://github.com/codacy/docs/pull/298.)