### PR TITLE
clean: Use Google Analytics config from mkdocs.yml

### DIFF
--- a/overrides/partials/integrations/analytics.html
+++ b/overrides/partials/integrations/analytics.html
@@ -1,13 +1,13 @@
 {% block analytics %}
 
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-B5Q5WTNDMD"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ config.google_analytics[0] }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'G-B5Q5WTNDMD');
+  gtag('config', '{{ config.google_analytics[0] }}');
 </script>
 
 {% endblock %}


### PR DESCRIPTION
This ensures that we only need to maintain the Google Analytics tracking code in the centralized mkdocs.yml file.

(This is related with the change in https://github.com/codacy/pulse-user-docs/commit/e34ab2f8d14900bad12cc0cdb47977465a3c3f47.)