### PR TITLE
feature: Add Codacy and MkDocs README badges

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,2 @@
+---
+exclude_paths: []

--- a/.github/workflows/mkdocs-deploy-gh-pages.yml
+++ b/.github/workflows/mkdocs-deploy-gh-pages.yml
@@ -1,4 +1,4 @@
-name: Publish docs via GitHub Pages
+name: MkDocs
 on:
   push:
     branches:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Pulse documentation
 
-<https://docs.pulse.codacy.com/>
+[![MkDocs](https://github.com/codacy/pulse-user-docs/workflows/MkDocs/badge.svg)](https://github.com/codacy/pulse-user-docs/actions?query=workflow%3AMkDocs) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/98d931319de2492db939d40f4b2a628e)](https://www.codacy.com/gh/codacy/pulse-user-docs/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=codacy/pulse-user-docs&amp;utm_campaign=Badge_Grade)
+
+<https://docs.pulse.codacy.com>
 
 ## Contributing to the documentation
 


### PR DESCRIPTION
Adds nice badges to the README, similar to those on [codacy/docs](https://github.com/codacy/docs#codacy-documentation).

(The MkDocs badge will only show up correctly when the updated workflow runs for the first time on `master`.)