### PR TITLE
clean: Use same site as app.pulse.codacy.com

### DIFF
--- a/overrides/partials/integrations/analytics.html
+++ b/overrides/partials/integrations/analytics.html
@@ -10,11 +10,11 @@
   gtag('config', '{{ config.google_analytics[0] }}');
 </script>
 
-<!-- Hotjar Tracking Code for docs.pulse.codacy.com -->
+<!-- Hotjar Tracking Code for app.pulse.codacy.com -->
 <script>
   (function(h,o,t,j,a,r){
       h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-      h._hjSettings={hjid:2250360,hjsv:6};
+      h._hjSettings={hjid:2248401,hjsv:6};
       a=o.getElementsByTagName('head')[0];
       r=o.createElement('script');r.async=1;
       r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;


### PR DESCRIPTION
This should allow us to see the path users do from the app to the docs and back.

What do you think @pauloribeiro-codacy?