### PR TITLE
feature: Mention Time to open and Time to review in GitHub integration PUL-392

### DIFF
--- a/docs/one-click-integrations.md
+++ b/docs/one-click-integrations.md
@@ -4,7 +4,10 @@ Pulse is developing "one-click integrations" for the most popular Git providers,
 
 ## GitHub
 
-Pulse integrates directly with GitHub to receive data about changes and deployments, necessary to calculate the metrics [Lead time for changes](metrics.md#lead-time-for-changes) and [Deployment frequency](metrics.md#deployment-frequency).
+Pulse integrates directly with GitHub to receive data about changes and deployments, necessary to calculate the metrics:
+
+-   [Lead time for changes](metrics.md#lead-time-for-changes) (including the sub-metrics [Time to open](metrics.md#time-to-open) and [Time to review](metrics.md#time-to-review))
+-   [Deployment frequency](metrics.md#deployment-frequency)
 
 !!! important
     Consider the following before using the GitHub integration:


### PR DESCRIPTION
Clarifies that the GitHub integration is able to provide data to calculate the new sub-metrics **Time to open** and **Time to review**:

![image](https://user-images.githubusercontent.com/60105800/110355789-84851880-8031-11eb-961e-97ab6d27e4fd.png)
