### PR TITLE
feature: Integrate ToC into sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ theme:
   logo: "assets/pulse-logo.png"
   features:
     - navigation.instant
+    - toc.integrate
   custom_dir: overrides
   icon:
     repo: fontawesome/regular/arrow-alt-circle-right

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.1.2
-mkdocs-material==6.1.0
+mkdocs-material==7.0.5
 pymdown-extensions==8.0.1


### PR DESCRIPTION
Similar to Codacy docs.
![Screenshot 2021-03-09 at 14 42 54](https://user-images.githubusercontent.com/593860/110488376-53b2eb00-80e6-11eb-981d-623e0d24826f.png)

During today's call, @rtfpessoa noticed it was hard to read the example code due to the ToC.

https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-integration