### PR TITLE
feature: Enable meta descriptions for Pulse documentation pages

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -3,6 +3,7 @@
     "incrementListMarker": false
   },
   "plugins": [
+    "remark-frontmatter",
     "preset-lint-consistent",
     "preset-lint-recommended",
     "lint-heading-increment",

--- a/docs/cli/examples.md
+++ b/docs/cli/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-The following are examples of scripts that we used to quickly populate our own Pulse dashboard with historical data.
+This page includes examples of scripts that we used to quickly populate our own Pulse dashboard with historical data.
 
 You can use the examples to understand better how you can integrate the Pulse CLI with your existing workflows, or adapt these examples to populate your Pulse dashboard with historical data from your team.
 

--- a/docs/cli/pushing-data-to-pulse.md
+++ b/docs/cli/pushing-data-to-pulse.md
@@ -1,6 +1,10 @@
+---
+description: Use the Pulse CLI to send information about changes, deployments, and incidents whenever they happen in the software delivery workflow of your primary application or service.
+---
+
 # Pushing data to Pulse
 
-To measure the performance of your team, you must send information to Pulse about the following key events whenever they happen in the software delivery workflow of your primary application or service:
+To measure the performance of your team you must send information to Pulse about the following key events whenever they happen in the software delivery workflow of your primary application or service:
 
 -   [Changes and deployments](#changes-and-deployments)
 -   [Incidents](#incidents)

--- a/docs/metrics/accelerate.md
+++ b/docs/metrics/accelerate.md
@@ -1,6 +1,6 @@
 # Accelerate metrics
 
-These metrics are calculated using strictly `changes`, `deployments` and `incidents` for a rolling window of the last 90 days.
+Pulse calculates the four key Accelerate metrics: [deployment frequency](#deployment-frequency), [lead time for changes](#lead-time-for-changes), [median time to recover](#median-time-to-recover), and [change failure rate](#change-failure-rate). These metrics are calculated using strictly `changes`, `deployments` and `incidents` for a rolling window of the last 90 days.
 
 ## Deployment frequency
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,11 @@ markdown_extensions:
   - toc:
       permalink: true
 
+# Plugins
+plugins:
+    - search
+    - meta-descriptions
+
 nav:
   - index.md
   - "Calculated metrics":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs==1.1.2
 mkdocs-material==7.0.5
 pymdown-extensions==8.0.1
+mkdocs-meta-descriptions-plugin==0.0.4


### PR DESCRIPTION
Enable and review meta descriptions for each Pulse documentation page.