### PR TITLE
fix: Fetch branch gh-pages before deploying docs

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v2.2.2

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/docs/CNAME"
           echo -e "User-agent: *\nSitemap: https://${CUSTOM_DOMAIN}/sitemap.xml" > "${GITHUB_WORKSPACE}/docs/robots.txt"
+          git fetch origin gh-pages --verbose
           mkdocs gh-deploy --config-file "${GITHUB_WORKSPACE}/mkdocs.yml"
         env:
           CUSTOM_DOMAIN: docs.pulse.codacy.com


### PR DESCRIPTION
This step is necessary after all, since we're not fetching the entire Git history with the action actions/checkout.