### PR TITLE
clean: The GitHub App can only be installed on organizations PUL-460

### DIFF
--- a/docs/one-click-integrations.md
+++ b/docs/one-click-integrations.md
@@ -15,7 +15,10 @@ To set up the GitHub integration:
 
 1.  On Pulse, [expand **Integrations** and select **GitHub**](https://app.pulse.codacy.com/integrations/github){: target="_blank"}.
 
-1.  Click **Install GitHub App** and follow the instructions on the GitHub UI to install the app in the desired organization.
+1.  Click **Install GitHub App** and follow the instructions on the GitHub UI to install the app on your organization.
+
+    !!! important
+        You can only install the Pulse GitHub App on an organization and not on your personal account.
 
     ![Installing the Pulse GitHub App](images/ghi-installing.png)
 


### PR DESCRIPTION
Adds a small note indicating that the Pulse GitHub App only works on GitHub organizations and not personal accounts:

![image](https://user-images.githubusercontent.com/60105800/117477123-83029e80-af55-11eb-9236-e13703c594b6.png)
