### PR TITLE
feature: Add reference for work in progress metrics PUL-468

### DIFF
--- a/docs/metrics/work-in-progress.md
+++ b/docs/metrics/work-in-progress.md
@@ -1,0 +1,20 @@
+# Work in progress metrics
+
+## Work in progress
+
+To provide you with an high-level view of the current work in progress of your teams, Pulse groups pull requests that are currently open by the following phases:
+
+-   **Open:** the pull request is open but the team hasn't interacted or reviewed it.
+-   **In review:** the pull request received at least one review but it isn't approved yet. Reviews include approvals, change requests, and inline pull request comments, but don't include conversation comments.
+-   **Approved:** the pull request received at least one approval.
+
+## Work in progress details
+
+The following metrics for each open pull request allow you to understand which work items are about to become or have become blockers and may need an action to move forward:
+
+-   **Time in progress:** number of days that the pull request is in progress.
+-   **Phase:** [current phase](#work-in-progress) of the pull request, can be one of **Open**, **In review**, or **Approved**.
+-   **Reviews:** number of reviews of the pull request. Reviews include approvals, change requests, and inline pull request comments, but don't include conversation comments.
+-   **Comments:** number of comments of the pull request.
+-   **Time stale:** number of days since the pull request had the last interaction.
+-   **Changes:** number of lines of code changed by the pull request.

--- a/docs/metrics/work-in-progress.md
+++ b/docs/metrics/work-in-progress.md
@@ -13,7 +13,7 @@ To provide you with an high-level view of the current work in progress of your t
 The following metrics for each open pull request allow you to understand which work items are about to become or have become blockers and may need an action to move forward:
 
 -   **Time in progress:** number of days that the pull request is in progress.
--   **Phase:** [current phase](#work-in-progress) of the pull request, can be one of **Open**, **In review**, or **Approved**.
+-   **Phase:** current phase of the pull request, can be one of **Open**, **In review**, or **Approved**.
 -   **Reviews:** number of reviews of the pull request. Reviews include approvals, change requests, and inline pull request comments, but don't include conversation comments.
 -   **Comments:** number of comments of the pull request.
 -   **Time stale:** number of days since the pull request had the last interaction.

--- a/docs/metrics/work-in-progress.md
+++ b/docs/metrics/work-in-progress.md
@@ -5,7 +5,7 @@
 To provide you with an high-level view of the current work in progress of your teams, Pulse groups pull requests that are currently open by the following phases:
 
 -   **Open:** the pull request is open but the team hasn't reviewed it.
--   **In review:** the pull request received at least one review but it isn't approved yet. These reviews include change requests and inline pull request comments, but don't include conversation comments.
+-   **Reviewed:** the pull request received at least one review but it isn't approved yet. These reviews include change requests and inline pull request comments, but don't include conversation comments.
 -   **Approved:** the pull request received at least one approval.
 
 ## Work in progress details
@@ -13,7 +13,7 @@ To provide you with an high-level view of the current work in progress of your t
 The following metrics for each open pull request allow you to understand which work items are about to become or have become blockers and may need an action to move forward:
 
 -   **Time in progress:** time since that pull request is in progress.
--   **Phase:** current phase of the pull request, can be one of **Open**, **In review**, or **Approved**.
+-   **Phase:** current phase of the pull request, can be one of **Open**, **Reviewed**, or **Approved**.
 -   **Reviews:** number of reviews of the pull request. Reviews include approvals, change requests, and inline pull request comments, but don't include conversation comments.
 -   **Comments:** number of comments of the pull request. Comments include inline pull request comments and conversation comments.
 -   **Time stale:** number of days since the pull request had the last interaction.

--- a/docs/metrics/work-in-progress.md
+++ b/docs/metrics/work-in-progress.md
@@ -4,17 +4,17 @@
 
 To provide you with an high-level view of the current work in progress of your teams, Pulse groups pull requests that are currently open by the following phases:
 
--   **Open:** the pull request is open but the team hasn't interacted or reviewed it.
--   **In review:** the pull request received at least one review but it isn't approved yet. Reviews include approvals, change requests, and inline pull request comments, but don't include conversation comments.
+-   **Open:** the pull request is open but the team hasn't reviewed it.
+-   **In review:** the pull request received at least one review but it isn't approved yet. These reviews include change requests and inline pull request comments, but don't include conversation comments.
 -   **Approved:** the pull request received at least one approval.
 
 ## Work in progress details
 
 The following metrics for each open pull request allow you to understand which work items are about to become or have become blockers and may need an action to move forward:
 
--   **Time in progress:** number of days that the pull request is in progress.
+-   **Time in progress:** time since that pull request is in progress.
 -   **Phase:** current phase of the pull request, can be one of **Open**, **In review**, or **Approved**.
 -   **Reviews:** number of reviews of the pull request. Reviews include approvals, change requests, and inline pull request comments, but don't include conversation comments.
--   **Comments:** number of comments of the pull request.
+-   **Comments:** number of comments of the pull request. Comments include inline pull request comments and conversation comments.
 -   **Time stale:** number of days since the pull request had the last interaction.
 -   **Changes:** number of lines of code changed by the pull request.

--- a/docs/one-click-integrations.md
+++ b/docs/one-click-integrations.md
@@ -12,6 +12,8 @@ Pulse integrates directly with GitHub to receive data about changes and deployme
 
     -   [Review metrics](metrics/lead-time-reviews.md#review-metrics)
 
+    -   [Work in progress metrics](metrics/work-in-progress.md)
+
 -   [Deployment frequency](metrics/accelerate.md#deployment-frequency)
 
 ### Setting up the GitHub integration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
   - "Calculated metrics":
     - metrics/accelerate.md
     - metrics/lead-time-reviews.md
+    - metrics/work-in-progress.md
   - one-click-integrations.md
   - "Pulse CLI":
     - cli/installing-the-pulse-cli.md


### PR DESCRIPTION
Adds descriptions for each metric that Pulse will present on the **Work in Progress** page.

### :construction: To do

- [ ] :hourglass: Wait until we release the new "Work in progress" page to merge this pull request