### PR TITLE
Change GA property

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ theme:
   icon:
     repo: fontawesome/regular/arrow-alt-circle-right
 
-google_analytics: ["G-B5Q5WTNDMD", "docs.pulse.codacy.com"]
+google_analytics: ["G-E31MPDGETR", "docs.pulse.codacy.com"]
 
 # Extensions
 markdown_extensions:


### PR DESCRIPTION
In the landing page, we'll be using a new property with support for both V4 and Universal versions of GA in order to be able to use Google Optimize.
This moves the docs analytics to the same property as the landing page.

Depends on codacy/pulse#612