### PR TITLE
feature: Add link to ingestion API reference docs PUL-625

### DIFF
--- a/docs/cli/pushing-data-to-pulse.md
+++ b/docs/cli/pushing-data-to-pulse.md
@@ -24,15 +24,7 @@ Consider the following before setting up the integration using the Pulse CLI:
 
 -   [**Make sure that you have an API key**](https://app.pulse.codacy.com/integrations/cli){: target="_blank"} provided by Pulse to identify your organization and authorize you to send data to Pulse.
 
--   In some scenarios, it may not be feasible to use the CLI to send data to Pulse, such as when reporting changes or incidents, or if you are reporting events from providers that only support webhooks.
-
-    For these situations, you can call an HTTP POST webhook instead. For example:
-
-    ```text
-    https://ingestion.pulse.codacy.com/v1/ingestion/<PROVIDER>?api_key=<API KEY>
-    ```
-
-    **Please let us know if you're planning on reporting events to Pulse using the webhook** so we can give you more detailed instructions on how to use it.
+-   In some scenarios, it may not be feasible to use the CLI to send data to Pulse, such as when reporting changes or incidents, or if you are reporting events from providers that only support webhooks. For these situations, you can [use the Pulse Ingestion API instead](https://ingestion.pulse.codacy.com/v1/api-docs){: target="_blank"}.
 
 ## Changes and deployments
 

--- a/docs/cli/pushing-data-to-pulse.md
+++ b/docs/cli/pushing-data-to-pulse.md
@@ -24,7 +24,7 @@ Consider the following before setting up the integration using the Pulse CLI:
 
 -   [**Make sure that you have an API key**](https://app.pulse.codacy.com/integrations/cli){: target="_blank"} provided by Pulse to identify your organization and authorize you to send data to Pulse.
 
--   In some scenarios, it may not be feasible to use the CLI to send data to Pulse, such as when reporting changes or incidents, or if you are reporting events from providers that only support webhooks. For these situations, you can [use the Pulse Ingestion API instead](https://ingestion.pulse.codacy.com/v1/api-docs){: target="_blank"}.
+-   In some scenarios, it may not be feasible to use the CLI to send data to Pulse, such as when you have the data inside an application. For these situations, you can [use the Pulse Ingestion API instead](https://ingestion.pulse.codacy.com/v1/api-docs){: target="_blank"}.
 
 ## Changes and deployments
 


### PR DESCRIPTION
For now, this is the minimal update so that we include a link to the ingestion API reference documentation, instead of asking users to contact us for more info. Later we can give more visibility to the API (placing it on equal footing with the CLI, for example) if we find this relevant.

Preview of the updated page:

https://github.com/codacy/pulse-user-docs/blob/feature/link-api-reference-PUL-625/docs/cli/pushing-data-to-pulse.md