### PR TITLE
toolchain: Update mkdocs-meta-descriptions-plugin to 1.0.1

### DIFF
--- a/docs/metrics/lead-time-reviews.md
+++ b/docs/metrics/lead-time-reviews.md
@@ -1,5 +1,7 @@
 # Lead time and review metrics
 
+Lead time for changes and review metrics provide an extra level of detail about the performance of your team workflows.
+
 ## Lead time for changes sub-metrics
 
 The following metrics directly influence **Lead time for changes**, and can help you track in more detail what needs to be improved in your workflow:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,8 @@ markdown_extensions:
 # Plugins
 plugins:
     - search
-    - meta-descriptions
+    - meta-descriptions:
+          export_csv: true
 
 nav:
   - index.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs==1.1.2
 mkdocs-material==7.0.5
 pymdown-extensions==8.1.1
-mkdocs-meta-descriptions-plugin==0.0.4
+mkdocs-meta-descriptions-plugin==1.0.1


### PR DESCRIPTION
Updates the version of the plugin that allows generating meta descriptions from the intros of each page. Also adds a missing intro.