### PR TITLE
toolchain: Disable unnecessary Netlify builds on pushes to master

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = 'if [ $BRANCH == "master" ]; then exit 0; else exit 1; fi'


### PR DESCRIPTION
Save Netlify build minutes by disabling builds on pushes to `master` since we're only using the service for previewing pull requests. :rocket: 

See https://github.com/codacy/docs/pull/821 and https://github.com/codacy/docs/pull/822 for a similar configuration on the codacy/docs repository.