### PR TITLE
toolchain: Activate verbose output for mkdocs build

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build docs
         run: |
-          mkdocs build
+          mkdocs -v build
 
       - name: Validate generated HTML files
         run: |
@@ -56,6 +56,6 @@ jobs:
           echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/docs/CNAME"
           echo -e "User-agent: *\nSitemap: https://${CUSTOM_DOMAIN}/sitemap.xml" > "${GITHUB_WORKSPACE}/docs/robots.txt"
           git fetch origin gh-pages --verbose
-          mkdocs gh-deploy --config-file "${GITHUB_WORKSPACE}/mkdocs.yml"
+          mkdocs -v gh-deploy --config-file "${GITHUB_WORKSPACE}/mkdocs.yml"
         env:
           CUSTOM_DOMAIN: docs.pulse.codacy.com


### PR DESCRIPTION
As of now, the build process for the Pulse docs is much simpler than the one for Codacy, but it's still a good idea to enable verbose output in line with https://github.com/codacy/docs/pull/1021.