### PR TITLE
feature: Improve intro for lead and cycle time metrics PUL-842

### DIFF
--- a/docs/metrics/lead-cycle-time.md
+++ b/docs/metrics/lead-cycle-time.md
@@ -2,10 +2,10 @@
 
 Monitoring you team's lead time and cycle time allows you to understand if you're improving the ability to deliver value to customers.
 
-![Lead time versus cycle time](images/lead-cycle-time.png)
-
 -   [Lead time](#lead-time)
 -   [Cycle time](#cycle-time)
+
+![Lead time versus cycle time](images/lead-cycle-time.png)
 
 !!! note
     Pulse calculates lead time and cycle time based on the state changes of issues **that are already closed** in Jira, independently of the resolution. This means that:

--- a/docs/metrics/lead-cycle-time.md
+++ b/docs/metrics/lead-cycle-time.md
@@ -1,11 +1,15 @@
 # Lead and cycle time metrics
 
-Monitoring you team's lead time and cycle time allows you to understand if you're improving the ability to deliver value to customers.
+Monitoring you team's lead time and cycle time allows you to understand if you're improving the ability to deliver value to customers. These productivity metrics indicate how long it takes for work to flow through the software development process:
 
--   [Lead time](#lead-time)
--   [Cycle time](#cycle-time)
+-   **[Lead time](#lead-time):** the time it takes to go from a customer making a request to the request being satisfied. Generally, you can use lead time as an indication of your organization’s time to market.
+-   **[Cycle time](#cycle-time):** the time it takes for your team to complete work items once they begin actively working on them.
 
 ![Lead time versus cycle time](images/lead-cycle-time.png)
+
+Use these metrics to monitor the results of investing in DevOps practices and tackling technical debt, compare and quantify the performance of your teams, and objectively communicate to stakeholders how long your Engineering team takes to address customer requests or defects.
+
+Read more on [how you can improve your time to market](https://blog.codacy.com/how-lead-time-can-improve-your-time-to-market/){: target="_blank"}.
 
 !!! note
     Pulse calculates lead time and cycle time based on the state changes of issues **that are already closed** in Jira, independently of the resolution. This means that:


### PR DESCRIPTION
Improves the introduction for the lead time and cycle time metrics, providing extra context to help explain the value of monitoring these metrics.

The information is based on our [recent blog post](https://blog.codacy.com/how-lead-time-can-improve-your-time-to-market/), which is also linked at the end of the introduction.