### PR TITLE
clean: Move Calculated metrics near the top of navigation tree

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,11 @@ plugins:
 
 nav:
   - index.md
+  - "Calculated metrics":
+    - metrics/accelerate.md
+    - metrics/accelerate-changes.md
+    - metrics/accelerate-wip.md
+    - metrics/lead-cycle-time.md
   - "One-click integrations":
     - one-click-integrations/github-integration.md
     - one-click-integrations/pagerduty-integration.md
@@ -60,8 +65,3 @@ nav:
     - cli/cli.md
     - cli/examples.md
   - "Pulse Ingestion API": https://ingestion.pulse.codacy.com/v1/api-docs
-  - "Calculated metrics":
-    - metrics/accelerate.md
-    - metrics/accelerate-changes.md
-    - metrics/accelerate-wip.md
-    - metrics/lead-cycle-time.md


### PR DESCRIPTION
For some time, I've been feeling that it makes sense to promote the section "Calculated metrics" to the top of the navigation tree. I feel that this provides a more natural flow of the documentation since it provides context about the value of the metrics before providing instructions for setting up the integrations.