### PR TITLE
feature: Mention the Pulse GitHub Action as an alternative to the CLI PUL-839

### DIFF
--- a/docs/cli/cli.md
+++ b/docs/cli/cli.md
@@ -42,7 +42,7 @@ Consider the following before setting up the integration using the Pulse CLI:
 Download the latest version of the Pulse CLI for your operating system and make sure that you're able to run the binary.
 
 !!! tip
-    **If you're using GitHub** we recommend that you use our [Pulse GitHub Action](https://github.com/codacy/pulse-action) as a more convenient way to report events directly from your GitHub Actions workflows.
+    **If you're using GitHub but our [one-click integration](../one-click-integrations/github-integration.md) doesn't fit your requirements** we recommend that you use our [Pulse GitHub Action](https://github.com/codacy/pulse-action) as a convenient way to report events directly from your GitHub Actions workflows.
 
     The Pulse GitHub Action acts as a wrapper for the Pulse CLI and accepts the same fields as the Pulse CLI.
 

--- a/docs/cli/cli.md
+++ b/docs/cli/cli.md
@@ -41,6 +41,11 @@ Consider the following before setting up the integration using the Pulse CLI:
 
 Download the latest version of the Pulse CLI for your operating system and make sure that you're able to run the binary.
 
+!!! tip
+    **If you're using GitHub** we recommend that you use our [Pulse GitHub Action](https://github.com/codacy/pulse-action) as a more convenient way to report events directly from your GitHub Actions workflows.
+
+    The Pulse GitHub Action acts as a wrapper for the Pulse CLI and accepts the same fields as the Pulse CLI.
+
 1.  Take note of the latest version of the CLI:
 
     ![Latest version](https://img.shields.io/github/v/release/codacy/pulse-event-cli?sort=semver)


### PR DESCRIPTION
For customers using GitHub, the Pulse GitHub Action is probably a more convenient way of reporting events to Pulse directly from their GitHub Actions workflows than running the Pulse CLI directly.

I decided to mention the Pulse GitHub Action right before the instructions for installing the Pulse CLI, as this is the place where users need to take the first step regarding setting up the reporting of events.

### :eyes: Live preview
https://deploy-preview-96--docs-pulse.netlify.app/cli/cli/#1-installing-the-pulse-cli