### PR TITLE
toolchain: Pin Jinja2 dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 mkdocs==1.2.3
 mkdocs-material==8.1.11
+Jinja2==3.0.3
 pymdown-extensions==9.2
 mkdocs-meta-descriptions-plugin==1.0.2


### PR DESCRIPTION
Since it's not the first time that the MkDocs build starts failing because of Jinja2 updates, it's better to permanently pin this dependency and control when we get updates through Dependabot.

See also https://github.com/mkdocs/mkdocs/issues/2799.