### PR TITLE
toolchain: Build branch deploy previews using GitHub Actions

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -43,6 +43,14 @@ jobs:
         with:
           string: ${{ steps.branches.outputs.sanitized-branch-name }}
 
+      - name: Truncate branch name
+        id: truncatedString
+        if: github.ref != 'refs/heads/master'
+        uses: 2428392/gh-truncate-string-action@v1.0.0
+        with:
+          stringToTruncate: ${{ steps.string.outputs.lowercase }}
+          maxLength: 35
+
       - name: Deploy docs (branch preview)
         if: github.ref != 'refs/heads/master'
         uses: nwtgck/actions-netlify@v1.2
@@ -55,7 +63,7 @@ jobs:
           enable-commit-comment: false
           enable-commit-status: false
           overwrites-pull-request-comment: false
-          alias: ${{ steps.string.outputs.lowercase }}
+          alias: ${{ steps.truncatedString.outputs.string }}
           github-deployment-environment: Netlify
           github-deployment-description: Branch deployment preview
         env:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -31,25 +31,11 @@ jobs:
           docker run -v $(pwd):/test --rm wjdp/htmltest --conf .htmltest.yml
 
       # On push to feature branch, deploy the docs to Netlify
-      - name: Determine branch name
-        id: branches
-        if: github.ref != 'refs/heads/master'
-        uses: transferwise/sanitize-branch-name@v1
-
-      - name: Convert branch name to lowercase
-        id: string
-        if: github.ref != 'refs/heads/master'
-        uses: ASzc/change-string-case-action@v2
-        with:
-          string: ${{ steps.branches.outputs.sanitized-branch-name }}
-
-      - name: Truncate branch name
-        id: truncatedString
-        if: github.ref != 'refs/heads/master'
-        uses: 2428392/gh-truncate-string-action@v1.0.0
-        with:
-          stringToTruncate: ${{ steps.string.outputs.lowercase }}
-          maxLength: 35
+      - name: Obtain Netlify alias from branch name
+        id: netlify-alias
+        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
+        run: |
+          echo "::set-output name=alias::$(echo ${GITHUB_REF#refs/heads/} | tr "/" "-" | tr "[:upper:]" "[:lower:]" | cut -c -35 | sed "s/-$//")"
 
       - name: Deploy docs (branch preview)
         if: github.ref != 'refs/heads/master'
@@ -63,7 +49,7 @@ jobs:
           enable-commit-comment: false
           enable-commit-status: false
           overwrites-pull-request-comment: false
-          alias: ${{ steps.truncatedString.outputs.string }}
+          alias: ${{ steps.netlify-alias.outputs.alias }}
           github-deployment-environment: Netlify
           github-deployment-description: Branch deployment preview
         env:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -36,6 +36,12 @@ jobs:
         if: github.ref != 'refs/heads/master'
         uses: transferwise/sanitize-branch-name@v1
 
+      - name: Convert branch name to lowercase
+        id: string
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ steps.branches.outputs.sanitized-branch-name }}
+
       - name: Deploy docs (branch preview)
         if: github.ref != 'refs/heads/master'
         uses: nwtgck/actions-netlify@v1.2
@@ -48,7 +54,7 @@ jobs:
           enable-commit-comment: false
           enable-commit-status: false
           overwrites-pull-request-comment: false
-          alias: ${{ steps.branches.outputs.sanitized-branch-name }}
+          alias: ${{ steps.string.outputs.lowercase }}
           github-deployment-environment: Netlify
           github-deployment-description: Branch deployment preview
         env:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -30,7 +30,32 @@ jobs:
         run: |
           docker run -v $(pwd):/test --rm wjdp/htmltest --conf .htmltest.yml
 
-      # On push to master, deploy the docs to GitHub pages
+      # On push to feature branch, deploy the docs to Netlify
+      - name: Determine branch name
+        id: branches
+        if: github.ref != 'refs/heads/master'
+        uses: transferwise/sanitize-branch-name@v1
+
+      - name: Deploy docs (branch preview)
+        if: github.ref != 'refs/heads/master'
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: ./site
+          production-branch: master
+          github-token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          deploy-message: Deploy for branch ${{ github.ref_name }}
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          enable-commit-status: false
+          overwrites-pull-request-comment: false
+          alias: ${{ steps.branches.outputs.sanitized-branch-name }}
+          github-deployment-environment: Netlify
+          github-deployment-description: Branch deployment preview
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PERSONAL_ACCESS_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+      # On push to master, deploy the docs to GitHub Pages
       - name: Set up git author
         if: github.ref == 'refs/heads/master'
         run: |

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -35,7 +35,7 @@ jobs:
         id: netlify-alias
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
         run: |
-          echo "::set-output name=alias::$(echo ${GITHUB_REF#refs/heads/} | tr "/" "-" | tr "[:upper:]" "[:lower:]" | cut -c -35 | sed "s/-$//")"
+          echo "::set-output name=alias::$(echo ${GITHUB_REF#refs/heads/} | tr -c -s "[:alnum:]" "-" | tr "[:upper:]" "[:lower:]" | cut -c -35 | sed "s/-*$//")"
 
       - name: Deploy docs (branch preview)
         if: github.ref != 'refs/heads/master'

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Convert branch name to lowercase
         id: string
+        if: github.ref != 'refs/heads/master'
         uses: ASzc/change-string-case-action@v2
         with:
           string: ${{ steps.branches.outputs.sanitized-branch-name }}

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           publish-dir: ./site
           production-branch: master
-          github-token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: Deploy for branch ${{ github.ref_name }}
           enable-pull-request-comment: false
           enable-commit-comment: false

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,0 @@
-[build]
-  ignore = 'if [ $BRANCH == "master" ]; then exit 0; else exit 1; fi'


### PR DESCRIPTION
This lets us overcome the 300 free CI minutes from Netlify since the builds are performed by a GitHub Actions workflow.

Applies the same change as the one from https://github.com/codacy/docs/pull/1165, https://github.com/codacy/docs/pull/1167, and https://github.com/codacy/docs/pull/1197.