### PR TITLE
toolchain: Pin markdown==3.3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 mkdocs==1.3.1
+markdown==3.3.7 # Temporarily pin version <3.4, see https://github.com/mkdocs/mkdocs/pull/2893
 mkdocs-material==8.3.9
 
 # Markdown extensions


### PR DESCRIPTION
After checking out the discussion on https://github.com/mkdocs/mkdocs/issues/2892, it seems that Markdown updates have some chance of breaking compatibility with mkdocs extensions.

Because of that, I think it's better to pin the Markdown version to ensure that we check that everything works fine on each pull request opened by Dependabot.