### PR TITLE
infra: Remove unneeded meta Markdown extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,6 @@ markdown_extensions:
       guess_lang: false
       linenums: true
   - footnotes
-  - meta
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true


### PR DESCRIPTION
I discovered that the meta Markdown [Meta-Data extension](https://python-markdown.github.io/extensions/meta_data/) is actually not needed since it's already included in MkDocs.

For more details, see https://github.com/squidfunk/mkdocs-material/issues/4179.