### PR TITLE
clean: Merge Jira App notes PUL-1281

### DIFF
--- a/docs/one-click-integrations/jira-integration.md
+++ b/docs/one-click-integrations/jira-integration.md
@@ -13,10 +13,9 @@ To set up the Jira integration:
     !!! important
         This step should be performed by a Jira administrator, since Pulse will only have access to Jira resources that the user setting up the integration has access to.
 
-    ![Installing the Pulse Jira app](images/jira-installing.png)
-
-    !!! note
         You can only integrate one Pulse organization with each Jira instance.
+
+    ![Installing the Pulse Jira app](images/jira-installing.png)
 
 1.  Wait until you get a confirmation that Pulse successfully created the integration and the necessary webhooks on Jira.
 


### PR DESCRIPTION
It's best to include both notes related to the Jira App installation in the same admonition card, otherwise, users may easily miss the note under the screenshot.