### PR TITLE
toolchain: Update netlify-alias GitHub Action step

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -35,7 +35,7 @@ jobs:
         id: netlify-alias
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
         run: |
-          echo "::set-output name=alias::$(echo ${GITHUB_REF#refs/heads/} | tr -c -s "[:alnum:]" "-" | tr "[:upper:]" "[:lower:]" | cut -c -35 | sed "s/-*$//")"
+          echo "alias=$(echo ${GITHUB_REF#refs/heads/} | tr -c -s "[:alnum:]" "-" | tr "[:upper:]" "[:lower:]" | cut -c -35 | sed "s/-*$//")" >> $GITHUB_OUTPUT
 
       - name: Deploy docs (branch preview)
         if: github.ref != 'refs/heads/master'


### PR DESCRIPTION
Replaces the `set-output` command, which is now deprecated: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

See also https://github.com/codacy/docs/pull/1473/.