### PR TITLE
toolchain: Add techwriters team to CODEOWNERS DOCS-453

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @codacy/pulse
+* @codacy/pulse @codacy/techwriters


### PR DESCRIPTION
Adds the techwriters team to CODEOWNERS file.