### PR TITLE
toolchain: Add enforce labels workflow DOCS-455

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -11,3 +11,4 @@ jobs:
     - uses: yogevbd/enforce-label-action@2.2.2
       with:
         BANNED_LABELS: "don't merge"
+

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,13 @@
+name: Enforce labels
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.2.2
+      with:
+        BANNED_LABELS: "don't merge"


### PR DESCRIPTION
Adds the workflow to prevent merging a pull request having the label "don't merge".