### PR TITLE
feat: Add permissions required for GitHub integration PUL-1443

### DIFF
--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -186,7 +186,7 @@ Pulse requests only the necessary permissions from GitHub to collect your organi
     <tr>
       <td>Members</td>
       <td>Read</td>
-      <td>Pulse retrieves information about organization members and teams to enforce permissions, user management, and billing purposes.</td>
+      <td>Pulse retrieves information about organization members and teams to enforce permissions, manage users, and for billing purposes.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -77,7 +77,7 @@ The following is a detailed description of how the Pulse GitHub integration auto
 
 -   In this case, you must send to Pulse the information about your **deployments** and the corresponding **changes** using the [Pulse CLI](../cli/cli.md) or the [Ingestion API](https://ingestion.pulse.codacy.com/v1/api-docs).
 
-## Collected data
+## Collected data {: id="collected-data"}
 
 The table below lists the data that the GitHub integration collects from your GitHub organization, together with:
 
@@ -138,6 +138,58 @@ The table below lists the data that the GitHub integration collects from your Gi
 <sup><span id="commit-author-date">1</span></sup>: Pulse uses the commit author's date since it is more accurate. The committer date can be changed (e.g.: rebases) and stop reflecting the real creation date of the change.
 
 <sup><span id="deployment-teams">2</span></sup>: Adding a new team or changing the composition of a team on GitHub only affects new data from that moment onwards and doesn't have an immediate impact on the dashboards. Also, deleted teams on GitHub will continue to show in Pulse.
+
+## Which permissions does Pulse need from GitHub? {: id="gh-permissions"}
+
+Pulse requests only the necessary permissions from GitHub to collect your organization changes and deployment data and [keeps your information secure](https://security.codacy.com/). See below the detailed list of permissions.
+
+<table>
+  <colgroup>
+    <col width="20%"/>
+    <col width="20%"/>
+    <col width="60%"/>
+  </colgroup>
+  <thead>
+    <tr>
+      <th>Scope</th>
+      <th>Permissions</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td colspan="3"><strong>Repository permissions:</strong></td>
+    </tr>
+    <tr>
+      <td>Pull requests</td>
+      <td>Read</td>
+      <td>Pulse retrieves pull request information to calculate several metrics.</td>
+    </tr>
+    <tr>
+      <td>Contents</td>
+      <td>Read</td>
+      <td>Pulse retrieves contents of files and directories in a repository to read tags and support semantic versioning.</td>
+    </tr>
+    <tr>
+      <td>Issues</td>
+      <td>Read</td>
+      <td>Pulse retrieves issue information to get the top-level comments of pull requests.</td>
+    </tr>
+    <tr>
+      <td colspan="3"><strong>Organization permissions:</strong></td>
+    </tr>
+    <tr>
+      <td>Webhooks</td>
+      <td>Read & Write</td>
+      <td>Pulse creates webhooks for organization and repository events (...) to calculate metrics. </td>
+    </tr>
+    <tr>
+      <td>Members</td>
+      <td>Read</td>
+      <td>Pulse retrieves information about organization members and teams to enforce permissions, user management, and billing purposes.</td>
+    </tr>
+  </tbody>
+</table>
 
 ## See also
 

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -163,7 +163,7 @@ Pulse requests only the necessary permissions from GitHub to collect your organi
     <tr>
       <td>Pull requests</td>
       <td>Read</td>
-      <td>Pulse retrieves pull request information to calculate several metrics.</td>
+      <td>Pulse retrieves pull request information to calculate several of the metrics presented on the dashboards. <a href="#collected-data"> See the details here.</a></td>
     </tr>
     <tr>
       <td>Contents</td>

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -186,7 +186,7 @@ Pulse requests only the necessary permissions from GitHub to collect changes and
     <tr>
       <td>Members</td>
       <td>Read</td>
-      <td>Pulse retrieves information about organization members and teams to enforce permissions, manage users, and for billing purposes.</td>
+      <td>Pulse retrieves information about organization members and teams for filtering metrics and billing purposes.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -168,7 +168,7 @@ Pulse requests only the necessary permissions from GitHub to collect changes and
     <tr>
       <td>Contents</td>
       <td>Read</td>
-      <td>Pulse retrieves tag information to support semantic versioning. For this, Pulse GitHub App requires read permission on contents of files and directories, as it's the same permission that applies to tags.</td>
+      <td>Pulse retrieves tag information to support semantic versioning. For this, the Pulse GitHub App requires read permission on contents of files and directories, as it's the same permission that applies to tags.</td>
     </tr>
     <tr>
       <td>Issues</td>

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -141,7 +141,7 @@ The table below lists the data that the GitHub integration collects from your Gi
 
 ## Which permissions does Pulse need from GitHub? {: id="gh-permissions"}
 
-Pulse requests only the necessary permissions from GitHub to collect your organization changes and deployment data and [keeps your information secure](https://security.codacy.com/). See below the detailed list of permissions.
+Pulse requests only the necessary permissions from GitHub to collect changes and deployment data from the repositories in your organization and [keeps your information secure](https://security.codacy.com/). See below the detailed list of permissions.
 
 <table>
   <colgroup>

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -181,7 +181,7 @@ Pulse requests only the necessary permissions from GitHub to collect your organi
     <tr>
       <td>Webhooks</td>
       <td>Read & Write</td>
-      <td>Pulse creates webhooks for organization and repository events (create, pull_request, pull_request_review) to calculate metrics. </td>
+      <td>Pulse creates webhooks for organization and repository events (`create`, `pull_request`, `pull_request_review`) to calculate metrics.</td>
     </tr>
     <tr>
       <td>Members</td>

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -168,7 +168,7 @@ Pulse requests only the necessary permissions from GitHub to collect changes and
     <tr>
       <td>Contents</td>
       <td>Read</td>
-      <td>Pulse retrieves tag information to support semantic versioning. For this, the Pulse GitHub App requires read permission on contents of files and directories, as it's the same permission that applies to tags.</td>
+      <td>Pulse retrieves tag information to support semantic versioning. For this, the Pulse GitHub App requires read permission on the contents of files and directories, as it's the same permission that applies to tags.</td>
     </tr>
     <tr>
       <td>Issues</td>
@@ -181,7 +181,7 @@ Pulse requests only the necessary permissions from GitHub to collect changes and
     <tr>
       <td>Webhooks</td>
       <td>Read & Write</td>
-      <td>Pulse creates webhooks for organization and repository events (`create`, `pull_request`, `pull_request_review`) to calculate metrics.</td>
+      <td>Pulse creates webhooks for organization and repository events (<code>create</code>, <code>pull_request</code>, <code>pull_request_review</code>) to calculate metrics.</td>
     </tr>
     <tr>
       <td>Members</td>

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -168,7 +168,7 @@ Pulse requests only the necessary permissions from GitHub to collect changes and
     <tr>
       <td>Contents</td>
       <td>Read</td>
-      <td>Pulse retrieves tag information to support semantic versioning. For this, the Pulse GitHub App requires read permission on the contents of files and directories, as it's the same permission that applies to tags.</td>
+      <td>Pulse retrieves tag information to track deployments via semantic versioning tags. For this, the Pulse GitHub App requires read permission on the contents of files and directories, as it's the same permission that applies to tags.</td>
     </tr>
     <tr>
       <td>Issues</td>
@@ -181,12 +181,17 @@ Pulse requests only the necessary permissions from GitHub to collect changes and
     <tr>
       <td>Webhooks</td>
       <td>Read & Write</td>
-      <td>Pulse creates webhooks for organization and repository events (<code>create</code>, <code>pull_request</code>, <code>pull_request_review</code>) to calculate metrics.</td>
+      <td>Pulse creates organization webhooks to track new or deleted repositories, and the status of the integration.<br/>Pulse also creates webhooks subscribed to the following repository events as a trigger to gather the corresponding data in real time:
+      <ul>
+        <li><code>create</code>: tags creation</li>
+        <li><code>pull_request</code>: pull requests creation, edition, and deletion</li>
+        <li><code>pull_request_review</code>: review creation, edition, and deletion</li>
+      </ul></td>
     </tr>
     <tr>
       <td>Members</td>
       <td>Read</td>
-      <td>Pulse retrieves information about organization members and teams for filtering metrics and billing purposes.</td>
+      <td>Pulse retrieves information about members and teams of your organization to filter metrics and for billing purposes.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -181,7 +181,7 @@ Pulse requests only the necessary permissions from GitHub to collect your organi
     <tr>
       <td>Webhooks</td>
       <td>Read & Write</td>
-      <td>Pulse creates webhooks for organization and repository events (...) to calculate metrics. </td>
+      <td>Pulse creates webhooks for organization and repository events (create, pull_request, pull_request_review) to calculate metrics. </td>
     </tr>
     <tr>
       <td>Members</td>

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -168,7 +168,7 @@ Pulse requests only the necessary permissions from GitHub to collect your organi
     <tr>
       <td>Contents</td>
       <td>Read</td>
-      <td>Pulse retrieves contents of files and directories in a repository to read tags and support semantic versioning.</td>
+      <td>Pulse retrieves tag information to support semantic versioning. For this, Pulse GitHub App requires read permission on contents of files and directories, as it's the same permission that applies to tags.</td>
     </tr>
     <tr>
       <td>Issues</td>

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -163,7 +163,7 @@ Pulse requests only the necessary permissions from GitHub to collect changes and
     <tr>
       <td>Pull requests</td>
       <td>Read</td>
-      <td>Pulse retrieves pull request information to calculate several of the metrics presented on the dashboards. <a href="#collected-data">See the details here.</a></td>
+      <td>Pulse retrieves pull request information to calculate several metrics presented on the dashboards. <a href="#collected-data">See the details here.</a></td>
     </tr>
     <tr>
       <td>Contents</td>

--- a/docs/one-click-integrations/github-integration.md
+++ b/docs/one-click-integrations/github-integration.md
@@ -77,7 +77,7 @@ The following is a detailed description of how the Pulse GitHub integration auto
 
 -   In this case, you must send to Pulse the information about your **deployments** and the corresponding **changes** using the [Pulse CLI](../cli/cli.md) or the [Ingestion API](https://ingestion.pulse.codacy.com/v1/api-docs).
 
-## Collected data {: id="collected-data"}
+## Collected data
 
 The table below lists the data that the GitHub integration collects from your GitHub organization, together with:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ markdown==3.3.7 # Temporarily pin version <3.4, see https://github.com/mkdocs/mk
 mkdocs-material==8.5.10
 
 # Markdown extensions
-pymdown-extensions==9.8
+pymdown-extensions==9.9
 
 # MkDocs plugins
 mkdocs-meta-descriptions-plugin==2.1.0


### PR DESCRIPTION
Adds a new table describing the permissions that Pulse requires from a GitHub organization and the corresponding purpose.

### :eyes: Live preview
https://feat-gh-permissions-pul-1443--docs-pulse.netlify.app/one-click-integrations/github-integration/#gh-permissions

### :construction: To do
-   [x] Get all missing details from the team
-   [x] Request review
