### PR TITLE
fix: Clarify heuristic for matching incidents and deployments PUL-1423

### DIFF
--- a/docs/metrics/accelerate.md
+++ b/docs/metrics/accelerate.md
@@ -65,7 +65,9 @@ Pulse uses the maximum value over a period of time to display aggregate times to
 
 <!--match-incident-deployment-start-->
 !!! note
-    We decided to avoid requiring a relationship between **incidents** and **deployments** or **changes** to simplify the data model reported.
+    **If your deployments have [systems](../cli/cli.md#before-you-begin), your incidents should too.**
+
+    We don't require that users specify which **deployment** should be associated with an  **incident** when sending the event, to simplify the complexity of the integration, as the events may originate from different data sources.
 
     As such, Pulse considers that the **deployment** for a [system](../cli/cli.md#before-you-begin) immediately before an **incident** for the same system is the one that caused that incident. The same deployment might be responsible for multiple incidents.
 

--- a/docs/metrics/accelerate.md
+++ b/docs/metrics/accelerate.md
@@ -67,9 +67,9 @@ Pulse uses the maximum value over a period of time to display aggregate times to
 !!! note
     We decided to avoid requiring a relationship between **incidents** and **deployments** or **changes** to simplify the data model reported.
 
-    As such, Pulse considers that the **deployment** for a system immediately before an **incident** for the same system is the one that caused that incident. The same deployment might be responsible for multiple incidents.
+    As such, Pulse considers that the **deployment** for a [system](../cli/cli.md#before-you-begin) immediately before an **incident** for the same system is the one that caused that incident. The same deployment might be responsible for multiple incidents.
 
-    Pulse calculates the performance metrics per system and later aggregates the metrics by time interval when displaying them. This means that you need both deployments and incidents for Pulse to correctly map the system between the two types of events and for the metrics to work.
+    Pulse calculates the performance metrics per system and later aggregates the metrics by time interval when displaying them. This means that you need both deployments and incidents for Pulse to correctly map the system between the two types of events and for the metrics to work. Otherwise, even if you're reporting incident events, the charts will be empty.
 <!--match-incident-deployment-end-->
 
 Pulse determines your performance level for this metric as follows:

--- a/docs/metrics/accelerate.md
+++ b/docs/metrics/accelerate.md
@@ -63,6 +63,15 @@ average(incident resolved timestamp - incident created timestamp)
 
 Pulse uses the maximum value over a period of time to display aggregate times to recover.
 
+<!--match-incident-deployment-start-->
+!!! note
+    We decided to avoid requiring a relationship between **incidents** and **deployments** or **changes** to simplify the data model reported.
+
+    As such, Pulse considers that the **deployment** for a system immediately before an **incident** for the same system is the one that caused that incident. The same deployment might be responsible for multiple incidents.
+
+    Pulse calculates the performance metrics per system and later aggregates the metrics by time interval when displaying them. This means that you need both deployments and incidents for Pulse to correctly map the system between the two types of events and for the metrics to work.
+<!--match-incident-deployment-end-->
+
 Pulse determines your performance level for this metric as follows:
 
 | Performance level[^1] | Time to recover              |
@@ -82,12 +91,12 @@ number of deployments that caused incidents / total number of deployments
 
 Pulse uses the average value over a period of time to display aggregate change failure rates.
 
-!!! note
-    We decided to avoid requiring a relationship between **incidents** and **deployments** or **changes** to simplify the data model reported.
+{%
+   include-markdown "accelerate.md"
+   start="<!--match-incident-deployment-start-->"
+   end="<!--match-incident-deployment-end-->"
+%}
 
-    As such, Pulse considers the **deployment** that caused an **incident** the closest deployment before the start of that **incident**. The same deployment might be responsible for multiple incidents.
-
-    Pulse calculates the performance metrics per system and later aggregates the metrics by time interval when displaying them. This means that you need both deployments and incidents for Pulse to correctly map the system between the two types of events and for the metrics to work.
 Pulse determines your performance level for this metric as follows:
 
 | Performance level[^1] | Change failure rate |

--- a/docs/metrics/accelerate.md
+++ b/docs/metrics/accelerate.md
@@ -64,13 +64,9 @@ average(incident resolved timestamp - incident created timestamp)
 Pulse uses the maximum value over a period of time to display aggregate times to recover.
 
 !!! note
-    **If your deployments have [systems](../cli/cli.md#before-you-begin), your incidents should too.**
+    **Pulse first calculates the performance metrics per [system](../cli/cli.md#before-you-begin)**, and later aggregates the metrics by time interval when displaying them.
 
-    We don't require that users specify which **deployment** should be associated with an  **incident** when sending the event, to simplify the complexity of the integration, as the events may originate from different data sources.
-
-    As such, Pulse considers that the **deployment** for a [system](../cli/cli.md#before-you-begin) immediately before an **incident** for the same system is the one that caused that incident. The same deployment might be responsible for multiple incidents.
-
-    Pulse calculates the performance metrics per system and later aggregates the metrics by time interval when displaying them. This means that you need both deployments and incidents for Pulse to correctly map the system between the two types of events and for the metrics to work. Otherwise, even if you're reporting incident events, the charts will be empty.
+    This means that you must report both deployments and incidents associated with the correct systems for Pulse to calculate the metrics correctly. Otherwise, even if you're reporting incident events, the charts will be empty.
 
 Pulse determines your performance level for this metric as follows:
 
@@ -92,13 +88,13 @@ number of deployments that caused incidents / total number of deployments
 Pulse uses the average value over a period of time to display aggregate change failure rates.
 
 !!! note
-    **If your deployments have [systems](../cli/cli.md#before-you-begin), your incidents should too.**
+    -   **Pulse first calculates the performance metrics per [system](../cli/cli.md#before-you-begin)**, and later aggregates the metrics by time interval when displaying them.
 
-    We don't require that users specify which **deployment** should be associated with an  **incident** when sending the event, to simplify the complexity of the integration, as the events may originate from different data sources.
+        This means that you must report both deployments and incidents associated with the correct systems for Pulse to calculate the metrics correctly. Otherwise, even if you're reporting incident events, the charts will be empty.
 
-    As such, Pulse considers that the **deployment** for a [system](../cli/cli.md#before-you-begin) immediately before an **incident** for the same system is the one that caused that incident. The same deployment might be responsible for multiple incidents.
+    -   Pulse considers that **the deployment causing each incident is the deployment immediately before the start of the incident**, within the same system. The same deployment may be associated with multiple incidents.
 
-    Pulse calculates the performance metrics per system and later aggregates the metrics by time interval when displaying them. This means that you need both deployments and incidents for Pulse to correctly map the system between the two types of events and for the metrics to work. Otherwise, even if you're reporting incident events, the charts will be empty.
+        This simplification reduces the complexity of the integration because it doesn't require any information about deployments or changes when reporting incidents, which could originate from a different data source.
 
 Pulse determines your performance level for this metric as follows:
 

--- a/docs/metrics/accelerate.md
+++ b/docs/metrics/accelerate.md
@@ -92,7 +92,7 @@ Pulse uses the average value over a period of time to display aggregate change f
 
         This means that you must report both deployments and incidents associated with the correct systems for Pulse to calculate the metrics correctly. Otherwise, even if you're reporting incident events, the charts will be empty.
 
-    -   Pulse considers that **the deployment causing each incident is the deployment immediately before the start of the incident**, within the same system. The same deployment may be associated with multiple incidents.
+    -   Pulse considers that **the deployment causing each incident is the last deployment before the incident**, within the same system. The same deployment may be associated with multiple incidents.
 
         This simplification reduces the complexity of the integration because it doesn't require any information about deployments or changes when reporting incidents, which could originate from a different data source.
 

--- a/docs/metrics/accelerate.md
+++ b/docs/metrics/accelerate.md
@@ -63,7 +63,6 @@ average(incident resolved timestamp - incident created timestamp)
 
 Pulse uses the maximum value over a period of time to display aggregate times to recover.
 
-<!--match-incident-deployment-start-->
 !!! note
     **If your deployments have [systems](../cli/cli.md#before-you-begin), your incidents should too.**
 
@@ -72,7 +71,6 @@ Pulse uses the maximum value over a period of time to display aggregate times to
     As such, Pulse considers that the **deployment** for a [system](../cli/cli.md#before-you-begin) immediately before an **incident** for the same system is the one that caused that incident. The same deployment might be responsible for multiple incidents.
 
     Pulse calculates the performance metrics per system and later aggregates the metrics by time interval when displaying them. This means that you need both deployments and incidents for Pulse to correctly map the system between the two types of events and for the metrics to work. Otherwise, even if you're reporting incident events, the charts will be empty.
-<!--match-incident-deployment-end-->
 
 Pulse determines your performance level for this metric as follows:
 
@@ -93,11 +91,14 @@ number of deployments that caused incidents / total number of deployments
 
 Pulse uses the average value over a period of time to display aggregate change failure rates.
 
-{%
-   include-markdown "accelerate.md"
-   start="<!--match-incident-deployment-start-->"
-   end="<!--match-incident-deployment-end-->"
-%}
+!!! note
+    **If your deployments have [systems](../cli/cli.md#before-you-begin), your incidents should too.**
+
+    We don't require that users specify which **deployment** should be associated with an  **incident** when sending the event, to simplify the complexity of the integration, as the events may originate from different data sources.
+
+    As such, Pulse considers that the **deployment** for a [system](../cli/cli.md#before-you-begin) immediately before an **incident** for the same system is the one that caused that incident. The same deployment might be responsible for multiple incidents.
+
+    Pulse calculates the performance metrics per system and later aggregates the metrics by time interval when displaying them. This means that you need both deployments and incidents for Pulse to correctly map the system between the two types of events and for the metrics to work. Otherwise, even if you're reporting incident events, the charts will be empty.
 
 Pulse determines your performance level for this metric as follows:
 

--- a/docs/metrics/accelerate.md
+++ b/docs/metrics/accelerate.md
@@ -18,7 +18,7 @@ number of deployments per day
 Pulse uses the average value over a period of time to display aggregate deployment frequencies.
 
 !!! note
-    Due to the way Pulse calculates deployment frequency, the absence of data will have an impact on reducing the value of this metric.
+    Due to the way Pulse calculates deployment frequency, **the absence of data will have an impact on reducing the value of this metric**.
 
     For example, suppose that you started developing a project 3 months ago and your deployment frequency over this time period was 2 deployments/day. If you increase the observed time interval to 6 months to include a time period before there were deployments, Pulse displays a deployment frequency of only 1 deployment/day.
 
@@ -40,7 +40,7 @@ median(deployment timestamp - changes timestamp)
 ```
 
 !!! note
-    The **changes** timestamp is when code is actually checked into a repository.
+    The changes timestamp is **when code is actually checked into a repository**.
 
 Pulse uses the maximum value over a period of time to display aggregate lead time for changes.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,9 +50,6 @@ markdown_extensions:
 # Plugins
 plugins:
     - search
-    # Include content from other Markdown files
-    # https://github.com/mondeja/mkdocs-include-markdown-plugin
-    - include-markdown
     # Generate meta descriptions from introductory paragraphs
     # https://github.com/prcr/mkdocs-meta-descriptions-plugin
     - meta-descriptions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,11 @@ markdown_extensions:
 # Plugins
 plugins:
     - search
+    # Include content from other Markdown files
+    # https://github.com/mondeja/mkdocs-include-markdown-plugin
+    - include-markdown
+    # Generate meta descriptions from introductory paragraphs
+    # https://github.com/prcr/mkdocs-meta-descriptions-plugin
     - meta-descriptions:
           export_csv: true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ mkdocs-material==8.5.11
 pymdown-extensions==9.9
 
 # MkDocs plugins
-mkdocs-include-markdown-plugin==4.0.0
 mkdocs-meta-descriptions-plugin==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ mkdocs-material==8.5.10
 pymdown-extensions==9.9
 
 # MkDocs plugins
+mkdocs-include-markdown-plugin==4.0.0
 mkdocs-meta-descriptions-plugin==2.1.0


### PR DESCRIPTION
Clarifies the heuristic that Pulse uses to match incidents and deployments, mentioning that the match only works for events sent for the same system, and repeats the note for both the **Time to recover** and **Change failure rate** metrics.

For context, see [this Slack thread](https://codacy.slack.com/archives/C019T4MJ1QX/p1668597349166979).

### :eyes: Live preview
- https://fix-match-incident-deployment-pul-1--docs-pulse.netlify.app/metrics/accelerate/#time-to-recover
- https://fix-match-incident-deployment-pul-1--docs-pulse.netlify.app/metrics/accelerate/#change-failure-rate