### PR TITLE
toolchain: Add workflow to create a Jira issue DOCS-490

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,0 +1,61 @@
+name: Create issue on Jira
+
+on:
+  issues:
+    types: opened
+
+jobs:
+  jira:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Jira login
+        id: login
+        uses: atlassian/gajira-login@v3.0.1
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Create Jira issue
+        id: create_jira_issue
+        uses: atlassian/gajira-create@v3.0.1
+        with:
+          project: DOCS
+          issuetype: Bug
+          summary: |
+            [GH#${{ github.event.issue.number }}] ${{ github.event.issue.title }}
+          description: |
+            ${{ github.event.issue.body }}
+            ----
+            {panel}
+            [Github permalink|${{ github.event.issue.html_url }}]
+            {panel}
+          fields: '{"customfield_10009": "DOCS-162"}'
+
+      - name: Update title of GitHub issue
+        uses: actions/github-script@v6
+        env:
+          JIRA_ISSUE_NUMBER: ${{ steps.create_jira_issue.outputs.issue }}
+          GITHUB_ORIGINAL_TITLE: ${{ github.event.issue.title }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const newTitle = `[${process.env.JIRA_ISSUE_NUMBER}] ${process.env.GITHUB_ORIGINAL_TITLE}`
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: newTitle
+            })
+
+      - name: Add comment to GitHub issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Internal Jira issue: [${{ steps.create_jira_issue.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_issue.outputs.issue }})'
+            })

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -30,7 +30,7 @@ jobs:
             {panel}
             [Github permalink|${{ github.event.issue.html_url }}]
             {panel}
-          fields: '{"customfield_10009": "DOCS-162"}'
+          fields: '{"customfield_10009": "DOCS-162", "labels": "Pulse"}'
 
       - name: Update title of GitHub issue
         uses: actions/github-script@v6


### PR DESCRIPTION
Adds the GitHub Actions workflow to automatically create an issue on Jira for any new GitHub issues created on the pulse-user-docs repository.