### PR TITLE
toolchain: Set Jira labels as array of strings DOCS-490

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -30,7 +30,7 @@ jobs:
             {panel}
             [Github permalink|${{ github.event.issue.html_url }}]
             {panel}
-          fields: '{"customfield_10009": "DOCS-162", "labels": "Pulse"}'
+          fields: '{"customfield_10009": "DOCS-162", "labels": ["Pulse"]}'
 
       - name: Update title of GitHub issue
         uses: actions/github-script@v6


### PR DESCRIPTION
After quickly testing the Jira workflow I realized that it wasn't working, but the solution to fix it should be quite simple, see https://github.com/codacy/pulse-user-docs/issues/168#issuecomment-1371302392.