### PR TITLE
toolchain: Disable markdownlint rule MD051

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -28,5 +28,6 @@
   "MD046": false,
   "MD048": {
     "style": "backtick"
-  }
+  },
+  "MD051": false
 }


### PR DESCRIPTION
See https://github.com/codacy/docs/pull/1585 for the rationale behind this change.