### PR TITLE
toolchain: Fix using personal token in mkdocs.yml DOCS-455

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           publish-dir: ./site
           production-branch: master
-          github-token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: Deploy for branch ${{ github.ref_name }}
           enable-pull-request-comment: false
           enable-commit-comment: false
@@ -82,7 +82,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/master'
         with:
-          github_token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          personal_token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
           publish_dir: ./site
           destination_dir: ./
           keep_files: false


### PR DESCRIPTION
Fixes a couple of details that we got wrong in https://github.com/codacy/pulse-user-docs/pull/179:

- The pull request previews can and should be performed using the `GITHUB_TOKEN`, otherwise, they appear as being made by the owner of the personal access token
- The GitHub action [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) actually [specifies a different input](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-personal-access-token-personal_token) for using personal access tokens