### PR TITLE
toolchain: Add workflow for scheduled jobs DOCS-507

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,6 +1,8 @@
 name: Scheduled jobs
 
-on: push
+on:
+  schedule:
+   - cron: "15 5 * * 1"
 
 jobs:
   check-broken-links:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -18,7 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.5.4
         with:
-          args: --verbose ./docs/**/*.md ./submodules/chart/docs/**/*.md
+          args: --verbose ./docs/**/*.md
           jobSummary: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -22,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create issue
-        if: steps.lychee.outputs.exit_code != 0
+        if: env.lychee_exit_code != 0
         uses: peter-evans/create-issue-from-file@v4
         with:
           title: Broken link report

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,60 @@
+name: Scheduled jobs
+
+on:
+  schedule:
+   - cron: "15 5 * * 1"
+
+jobs:
+  check-broken-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          submodules: true
+
+      - name: Check for broken links
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.5.4
+        with:
+          args: --verbose ./docs/**/*.md ./submodules/chart/docs/**/*.md
+          jobSummary: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create issue
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Broken link report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue
+
+  compress-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          submodules: true
+
+      - name: Compress images
+        id: calibre
+        uses: calibreapp/image-actions@main
+        with:
+          githubToken: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          ignorePaths: submodules/**
+          compressOnly: true
+
+      - name: Create pull request
+        if: steps.calibre.outputs.markdown != ''
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: "clean: Compress images"
+          branch-suffix: timestamp
+          commit-message: "clean: Compress images"
+          body: ${{ steps.calibre.outputs.markdown }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -45,7 +45,6 @@ jobs:
         uses: calibreapp/image-actions@main
         with:
           githubToken: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
-          ignorePaths: submodules/**
           compressOnly: true
 
       - name: Create pull request

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,8 +1,6 @@
 name: Scheduled jobs
 
-on:
-  schedule:
-   - cron: "15 5 * * 1"
+on: push
 
 jobs:
   check-broken-links:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+# Ignore internal links
+^[^h].*$


### PR DESCRIPTION
Adds the GitHub Actions workflow to run the following tasks automatically every Monday morning:

- Check for broken links pointing to external URLs and create an issue if there are broken links
- Run the [Calibre GitHub App](https://github.com/calibreapp/image-actions) and open a pull request to update any recently updated images with smaller file versions that look visually identical