### PR TITLE
clean: Clarify how Pulse collects the issue status from Jira

### DIFF
--- a/docs/metrics/lead-cycle-time.md
+++ b/docs/metrics/lead-cycle-time.md
@@ -3,6 +3,7 @@
 Monitoring you team's lead time and cycle time allows you to understand if you're improving the ability to deliver value to customers. These productivity metrics indicate how long it takes for work to flow through the software development process:
 
 -   **[Lead time](#lead-time):** the time it takes to go from a customer making a request to the request being satisfied. You can use lead time as an indication of your organization’s time to market.
+
 -   **[Cycle time](#cycle-time):** the time it takes for your team to complete work items once they begin actively working on them.
 
 ![Lead time versus cycle time](images/lead-cycle-time.png)
@@ -12,7 +13,7 @@ Use these metrics to monitor the results of investing in DevOps practices and ta
 Read more on [how you can improve your time to market](https://blog.codacy.com/how-lead-time-can-improve-your-time-to-market/){: target="_blank"}.
 
 !!! note
-    Pulse calculates lead time and cycle time based on the state changes of issues **that are already closed** in Jira, independently of the resolution. This means that:
+    Pulse calculates lead time and cycle time based on the state changes of issues **that are already completed** in your issue tracking system. This means that:
 
     -   **If you reopen** a completed issue, Pulse stops considering the issue while calculating the metrics. If the issue is completed again, Pulse takes into account the last completed timestamp.
 
@@ -20,11 +21,13 @@ Read more on [how you can improve your time to market](https://blog.codacy.com/h
     
         Note that this change doesn't affect the overall calculation of the lead time or cycle time metrics.
 
+    [See here](../one-click-integrations/jira-integration.md#collected-data) how Pulse collects issue status data from Jira.
+
 ## Lead time
 
 Time between creating an issue in the backlog and completing the issue.
 
-Pulse calculates lead time for completed issues, taking into account that issues can transition from **Completed** back to another status.
+Pulse calculates lead time for completed issues, taking into account that issues can transition from **completed** back to another state.
 
 ```text
 last issue completed timestamp - issue created timestamp
@@ -34,13 +37,12 @@ last issue completed timestamp - issue created timestamp
 
 Time between commiting to work on an issue (such as at the start of a sprint) and completing the issue. Cycle time is a subpart of lead time.
 
-Pulse calculates cycle time for completed issues, taking into account that issues can transition from **In progress** back to another status besides **Completed**.
+Pulse calculates cycle time for completed issues, taking into account that issues can transition from **in progress** back to another state besides **completed**.
 
 !!! note
-    When calculating cycle time, Pulse considers that:
+    Issues that aren't being worked on don't contribute to the cycle time.
 
-    -   Issues are in progress when they transition to any Jira status belonging to the **In Progress** status category (represented by the blue color in Jira).
-    -   Issues that have a status belonging to the **To Do** status category (represented by the grey color in Jira) don't contribute to cycle time.
+    In Jira, issues aren't being worked on when its status maps to the **To-do status category**. [See here](../one-click-integrations/jira-integration.md#collected-data) how Pulse collects issue status data from Jira.
 
 ```text
 sum all (issue exited in progress timestamp - issue entered in progress timestamp)

--- a/docs/one-click-integrations/jira-integration.md
+++ b/docs/one-click-integrations/jira-integration.md
@@ -48,7 +48,7 @@ You can also choose [not to detect incidents via Jira](#jira-incident-not-detect
 
 ### Use issues assigned with the label "Incident" {: id="jira-incident-label"}
 
--   Pulse considers an incident every Jira issue in a **Done** status assigned with the label `Incident` (case-insensitive). **Done** status in Jira are all the status of an issue under the [Done category](https://support.atlassian.com/jira-work-management/docs/workflows-and-statuses-for-the-board/) (represented by the green color in Jira). Some examples are **DONE**, **CLOSED**, or **DECLINED**, but other values can be defined.
+-   Pulse considers an incident every completed Jira issue assigned with the label `Incident` (case-insensitive). An issue is completed when its status maps to the **Done status category** in Jira. [See below](#collected-data) how Pulse collects issue status data from Jira.
 
 -   Pulse associates an incident to one or more systems matching the values in the **Component(s)** field of the Jira issue (case-sensitive).
 
@@ -56,15 +56,15 @@ You can also choose [not to detect incidents via Jira](#jira-incident-not-detect
 
     -   If the **Component(s)** field in the Jira issue is empty, or none of the components exist in Pulse as a system, Pulse creates an incident and associates it with the system `_unknown_`.
 
--   The incident creation date is the timestamp when the Jira issue was created, while the incident resolution date is the timestamp when the Jira issue was last updated to a **Done** status.
+-   The incident creation date is the timestamp when the Jira issue was created, while the incident resolution date is the timestamp when the Jira issue was last completed.
 
 -   Pulse creates new incidents when the following updates are performed in Jira:
 
-    -   The status of an issue assigned with the label `Incident` is updated to a **Done** status. Pulse creates one or more incidents, depending on the values in the **Component(s)** field.
+    -   An issue assigned with the label `Incident` is completed. Pulse creates one or more incidents, depending on the values in the **Component(s)** field.
 
-    -   An issue in a **Done** status is assigned with the label `Incident`. Pulse creates one or more incidents, depending on the values in the **Component(s)** field.
+    -   A completed issue is assigned with the label `Incident`. Pulse creates one or more incidents, depending on the values in the **Component(s)** field.
 
-    -   A new component that matches an existing system is added to an issue in a **Done** status assigned with the label `Incident`. Pulse creates a new incident associated with the matching system.
+    -   A new component that matches an existing system is added to a completed issue assigned with the label `Incident`. Pulse creates a new incident associated with the matching system.
 
 -   Pulse deletes an existing incident when the following updates are performed in Jira:
 
@@ -78,7 +78,7 @@ You can also choose [not to detect incidents via Jira](#jira-incident-not-detect
 
 !!! important
     After completing the Jira integration setup, Pulse starts loading your incident data for the last 90 days. Therefore, **before you perform the integration setup**, make sure the corresponding Jira issues follow the rules described above, so Pulse can load your historical data correctly.
-    Pulse will only create incidents for the Jira issues in a **Done** status that are assigned with the label `Incident`, and associates them with the systems matching the values in the **Component(s)** field as described above.
+    Pulse will only create incidents for the completed Jira issues that are assigned with the label `Incident`, and associates them with the systems matching the values in the **Component(s)** field as described above.
 
 ### Don't detect incidents via Jira {: id="jira-incident-not-detect"}
 
@@ -102,7 +102,13 @@ The table below lists the data that the Jira integration collects from your Jira
     <tr>
         <td>Issues</td>
         <td>
-            Issue data includes all issue status transitions.
+            Issue data includes all issue status transitions.<br/><br/>
+            To detect the state of an issue, Pulse considers all the statuses under each <a href="https://support.atlassian.com/jira-work-management/docs/workflows-and-statuses-for-the-board/">Jira status category</a>:
+            <ul>
+                <li>An issue is <strong>not being worked on</strong> when its status maps to the <strong>To-do status category</strong>, represented by the grey color in Jira. For example, <strong>BACKLOG</strong>, <strong>WAITING FOR APPROVAL</strong>, or any other custom value.</li>
+                <li>An issue is <strong>in progress</strong> when its status maps to the <strong>In-progress status category</strong>, represented by the blue color in Jira. For example, <strong>IN PROGRESS</strong>, <strong>DEVELOPING</strong>, <strong>IN REVIEW</strong>, or any other custom value.</li>
+                <li>An issue is <strong>completed</strong> when its status maps to the <strong>Done status category</strong>, represented by the grey color in Jira. For example, <strong>DONE</strong>, <strong>CLOSED</strong>, <strong>DECLINED</strong>, or any other custom value.</li>
+            </ul>
         </td>
         <td>Lead time and Cycle time on the <a href="../../metrics/lead-cycle-time/">Lead & Cycle time dashboard</a></td>
     </tr>


### PR DESCRIPTION
Clarifies how Pulse collects the issue status data from Jira, describing the several statuses under the three Jira status categories. Also, moved these Jira details from the Lead and cycle time metrics page to the Jira integration page.


### :eyes: Live preview
<!-- URL of the pages changed on the branch preview deployment -->
