### PR TITLE
fix: Add that an incident report requires a previous deployment

### DIFF
--- a/docs/metrics/accelerate.md
+++ b/docs/metrics/accelerate.md
@@ -70,6 +70,10 @@ Pulse uses the maximum value over a period of time to display aggregate times to
 
         If you are reporting incidents using [GitHub](../one-click-integrations/github-integration.md) or [Bitbucket](../one-click-integrations/bitbucket-integration.md) integrations, Pulse automatically associates your deployments and incidents with the correct systems.
 
+    -   Pulse associates an incident to **the last deployment before the incident**, within the same system. If you report an incident and there is no previous deployment for the same system, Pulse doesn't consider it. The same deployment may be associated with multiple incidents.
+
+        This simplification reduces the complexity of the integration because it doesn't require any information about deployments or changes when reporting incidents, which could originate from a different data source.
+
 Pulse determines your performance level for this metric as follows:
 
 | Performance level[^1] | Time to recover              |

--- a/docs/metrics/accelerate.md
+++ b/docs/metrics/accelerate.md
@@ -70,7 +70,7 @@ Pulse uses the maximum value over a period of time to display aggregate times to
 
         If you are reporting incidents using [GitHub](../one-click-integrations/github-integration.md) or [Bitbucket](../one-click-integrations/bitbucket-integration.md) integrations, Pulse automatically associates your deployments and incidents with the correct systems.
 
-    -   Pulse associates an incident to **the last deployment before the incident**, within the same system. If you report an incident and there is no previous deployment for the same system, Pulse doesn't consider it. The same deployment may be associated with multiple incidents.
+    -   Pulse associates an incident with **the last deployment before the incident**, within the same system. If you report an incident and there is no previous deployment for the same system, Pulse ignores the incident. The same deployment may be associated with multiple incidents.
 
         This simplification reduces the complexity of the integration because it doesn't require any information about deployments or changes when reporting incidents, which could originate from a different data source.
 


### PR DESCRIPTION
Adds a note for the **Time to recover** metric indicating that an incident report requires a previous deployment, otherwise, it's not considered by Pulse.

### :eyes: Live preview
https://fix-add-note-for-time-to-recover--docs-pulse.netlify.app/metrics/accelerate/#time-to-recover
